### PR TITLE
Remove Mapnik Release flag

### DIFF
--- a/mapnik.go
+++ b/mapnik.go
@@ -54,7 +54,6 @@ type version struct {
 	Major   int
 	Minor   int
 	Patch   int
-	Release bool
 	String  string
 }
 
@@ -65,7 +64,6 @@ func init() {
 	Version.Major = int(C.mapnik_version_major)
 	Version.Minor = int(C.mapnik_version_minor)
 	Version.Patch = int(C.mapnik_version_patch)
-	Version.Release = int(C.mapnik_version_release) != 0
 	Version.String = C.GoString(C.mapnik_version_string)
 }
 

--- a/mapnik_c_api.cpp
+++ b/mapnik_c_api.cpp
@@ -35,7 +35,6 @@ const char *mapnik_version_string = MAPNIK_VERSION_STRING;
 const int mapnik_version_major = MAPNIK_MAJOR_VERSION;
 const int mapnik_version_minor = MAPNIK_MINOR_VERSION;
 const int mapnik_version_patch = MAPNIK_PATCH_VERSION;
-const int mapnik_version_release = MAPNIK_VERSION_IS_RELEASE;
 
 #ifdef MAPNIK_2
     typedef mapnik::image_32 mapnik_rgba_image;

--- a/mapnik_c_api.h
+++ b/mapnik_c_api.h
@@ -18,7 +18,6 @@ extern const char *mapnik_version_string;
 extern const int mapnik_version_major;
 extern const int mapnik_version_minor;
 extern const int mapnik_version_patch;
-extern const int mapnik_version_release;
 
 MAPNIKCAPICALL int mapnik_register_datasources(const char* path);
 MAPNIKCAPICALL int mapnik_register_fonts(const char* path);


### PR DESCRIPTION
The Mapnik release tag needs to remove to use Mapnik 3.0.7 and up, as documented in the release notes here: https://github.com/mapnik/mapnik/blob/8813e73cfccc5f5339296a81512590aa828c7716/CHANGELOG.md#307

Documentation about this change to Mapnik is available here: https://github.com/mapnik/mapnik/issues/3123